### PR TITLE
Fix postinst script

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-knxd-config (1.1.6) stable; urgency=medium
+
+  * Fix postinst script
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 18 Apr 2025 12:30:00 +0400
+
 wb-knxd-config (1.1.5) stable; urgency=medium
 
   * Allow non-ncn5120 interface drivers

--- a/debian/control
+++ b/debian/control
@@ -1,8 +1,8 @@
 Source: wb-knxd-config
-Maintainer: Nikita Maslov <nikita.maslov@wirenboard.ru>
+Maintainer: Wiren Board team <info@wirenboard.com>
 Section: misc
 Priority: optional
-Standards-Version: 1.0.0
+Standards-Version: 4.5.0
 Build-Depends: debhelper (>= 9), pkg-config
 Homepage: https://github.com/wirenboard/wb-knxd-config/
 

--- a/debian/wb-knxd-config.postinst
+++ b/debian/wb-knxd-config.postinst
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-addgroup knxd dialout >/dev/null
+usermod -a -G dialout knxd >/dev/null
 
 # Force-restart wb-knxd-config if upgrading from old versions.
 #


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Fix install error on debian 13:
```sh
Setting up wb-knxd-config (1.1.5) ...
fatal: addgroup with two arguments is an unspecified operation.
```

___________________________________
**Что поменялось для пользователей:**
Nothing.

___________________________________
**Как проверял/а:**


